### PR TITLE
fix: normaliza valores de infração na importação CSV

### DIFF
--- a/services/document_parser/streams.py
+++ b/services/document_parser/streams.py
@@ -20,6 +20,21 @@ from services.document_parser.pubsub import AsyncMessageProcessor
 from services.parsers import normalize_auto_infraction_id
 from services.recurso_service import RecursoService
 
+
+def _parse_val_infr(value: Any) -> float | None:
+    """Convert optional Brazilian currency text into a database-ready number."""
+    if pd.isna(value):
+        return None
+
+    normalized = str(value).replace("R$", "").strip()
+    if not normalized:
+        return None
+    if "," in normalized:
+        normalized = normalized.replace(".", "").replace(",", ".")
+
+    return float(pd.to_numeric(normalized))
+
+
 # ==========================================
 # WRITE STREAMS (Output)
 # ==========================================
@@ -301,9 +316,7 @@ class InfracoesTransformStream(TransformStream[pd.DataFrame, List[Dict[str, Any]
             )
 
             if self.convert_val_infr and "VAL_INFR" in data_frame.columns:
-                data_frame["VAL_INFR"] = data_frame["VAL_INFR"].map(
-                    lambda x: pd.to_numeric(str(x).replace(",", "."))
-                )
+                data_frame["VAL_INFR"] = data_frame["VAL_INFR"].map(_parse_val_infr)
 
             if "DAT_CANC" in data_frame.columns and not bool(
                 data_frame["DAT_CANC"].isnull().all()

--- a/tests/parsers_test.py
+++ b/tests/parsers_test.py
@@ -1,11 +1,16 @@
 import os
 import tempfile
 
+import numpy as np
+import pandas as pd
 import pytest
 from docx import Document
 
 from exceptions.CustomExceptions import ErrDataPubli
-from services.document_parser.streams import RecursosDocxInputStream
+from services.document_parser.streams import (
+    InfracoesTransformStream,
+    RecursosDocxInputStream,
+)
 from services.parsers import normalize_auto_infraction_id
 
 
@@ -14,6 +19,31 @@ def test_normalize_auto_infraction_id():
     assert normalize_auto_infraction_id("12345-A") == "12345-A"
     assert normalize_auto_infraction_id("1234-") == "1234-"
     assert normalize_auto_infraction_id("") == ""
+
+
+def test_infracoes_transform_accepts_brazilian_currency_and_missing_value():
+    data_frame = pd.DataFrame(
+        {
+            "NUM_AI": ["12345-A", "12346-A"],
+            "DAT_OCOR_INFR": ["01/09/2026", "02/09/2026"],
+            "HORA": ["10:30", "11:45"],
+            "DAT_EMIS_NOTF": ["01/09/2026", np.nan],
+            "DAT_LIMT_RECU": ["15/09/2026", np.nan],
+            "VAL_INFR": ["R$ 1.498,91", np.nan],
+        }
+    )
+    stream = InfracoesTransformStream(
+        datetime_format="%d/%m/%Y %H:%M",
+        date_format="%d/%m/%Y",
+        convert_val_infr=True,
+    )
+
+    records = stream.transform(data_frame)
+
+    assert records[0]["VAL_INFR"] == 1498.91
+    assert records[1]["VAL_INFR"] is None
+    assert records[1]["DAT_EMIS_NOTF"] is None
+    assert records[1]["DAT_LIMT_RECU"] is None
 
 
 def test_recursos_docx_stream():


### PR DESCRIPTION
## Resumo
- normaliza valores brasileiros de `VAL_INFR`, com ou sem `R$` e separador de milhar
- trata valores monetários ausentes como `NULL`, conforme permitido pelo modelo
- adiciona cobertura para moeda brasileira e campos opcionais ausentes
- não inclui os arquivos da pasta `import`

## Validação
- `pytest -q tests/parsers_test.py`: 4 testes aprovados
- `ruff check` e `ruff format --check`: aprovados
- 12 CSVs, totalizando 10.276 registros, passaram pelo leitor, transformador e modelo do backend

## Observação
A suíte completa depende do host MySQL `bonfire-db`, indisponível no ambiente local; os testes relacionados à mudança passaram.